### PR TITLE
feat: added address interface to updating address for both user & store request

### DIFF
--- a/src/types/http/address.type.ts
+++ b/src/types/http/address.type.ts
@@ -1,6 +1,14 @@
+import mongoose from "mongoose";
+import { AddressProps } from "../model/address.type";
+
 export interface GetDistrictRequestProps {
   province_id?: number;
 }
 export interface GetWardRequestProps {
   district_id?: number;
+}
+
+export interface AddressRequestProps {
+  _id: mongoose.Types.ObjectId;
+  address: AddressProps;
 }

--- a/src/types/model/address.type.ts
+++ b/src/types/model/address.type.ts
@@ -35,7 +35,7 @@ export interface WardAddressProps extends GHNAddressProps {
 }
 
 export interface AddressProps {
-  _id: mongoose.Schema.Types.ObjectId;
+  _id: mongoose.Types.ObjectId;
   address: string;
   ward: WardAddressProps;
   district: DistrictAddressProps;

--- a/src/validations/address.validation.ts
+++ b/src/validations/address.validation.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
 import Joi from 'joi';
-import { ObjectIDRegex } from '../constants/validation';
 import {
   AddressProps,
   DistrictAddressProps,
@@ -11,6 +10,7 @@ import {
 } from '../types/model/address.type';
 import { catchErrors } from '../utils/catchErrors';
 import { CommonValidation } from './common.validation';
+import { AddressRequestProps } from '../types/http/address.type';
 
 interface GHNAddressSchema extends GHNAddressProps {}
 interface ProvincesAddressSchema extends ProvincesAddressProps {}
@@ -61,7 +61,9 @@ const addressSchema = Joi.object<AddressSchema>({
 });
 
 export const userAddress = catchErrors(async (req: Request, res: Response, next: NextFunction) => {
-  await addressSchema.validateAsync(req.body, { abortEarly: true });
+  const { _id, address } = req.body as AddressRequestProps;
+  await addressSchema.validateAsync(address, { abortEarly: true });
+  await idSchema.validateAsync(_id, { abortEarly: true });
   next();
 });
 


### PR DESCRIPTION
## PUT: `/users/address`
### Body: `AddressRequestProps`:
- `_id` : userID or storeID (Only accept userID at this API)
- `address`: AddressProps

Data:
![image](https://github.com/user-attachments/assets/b7fa9b52-064b-4250-bd3d-ffbe4551ffff)
