### PR TITLE
chore: added 'items' prop to the calcShippingFeeRequest type

### DIFF
--- a/src/types/http/ghn.type.ts
+++ b/src/types/http/ghn.type.ts
@@ -1,3 +1,5 @@
+import { ProductProps } from '../model/product.type';
+
 export interface GHNResponseProps {
   code: number;
   message: string;
@@ -30,3 +32,6 @@ export interface GetAvailableServiceResponseProps extends GHNResponseProps {
     service_type_id: number;
   }[];
 }
+
+export interface CalcShippingFeeItemProps
+  extends Pick<ProductProps, 'name' | 'quantity' | 'height' | 'weight' | 'length' | 'width'> {}

--- a/src/types/http/order.type.ts
+++ b/src/types/http/order.type.ts
@@ -1,5 +1,5 @@
 import { OrderProps } from '../model/order.type';
-import { GHNResponseProps } from './ghn.type';
+import { CalcShippingFeeItemProps, GHNResponseProps } from './ghn.type';
 import { MoMoPaymentItemsProps } from './momoPayment.type';
 import { PaginationRequestProps } from './pagination.type';
 
@@ -20,6 +20,7 @@ export interface CalcShippingFeeRequestProps {
   length?: number;
   width?: number;
   cod_value?: number;
+  items?: CalcShippingFeeItemProps[];
 }
 export interface CalcShippingFeeResponseProps extends GHNResponseProps {
   data: {


### PR DESCRIPTION
### CalcShippingFeeRequestProps: 
- . . .
- items: `CalcShippingFeeItemProps [ ]`

### CalcShippingFeeItemProps: _(extends ProductPruct)_
- name
- quantity
- height
- weight
- length
- width