### PR TITLE
feat: defined an api to calculating the expected delivery time

### DIFF
--- a/src/apis/ghn.ts
+++ b/src/apis/ghn.ts
@@ -8,6 +8,8 @@ import {
   GetAvailableServiceResponseProps,
 } from '../types/http/ghn.type';
 import {
+  CalcExpectedDeliveryDateRequest,
+  CalcExpectedDeliveryDateResponse,
   CalcShippingFeeRequestProps,
   CalcShippingFeeResponseProps,
 } from '../types/http/order.type';
@@ -22,6 +24,7 @@ const createStoreUrl = `/v2/shop/register`;
 const getServiceUrl = `/v2/shipping-order/available-services`;
 const calcShippingFeeUrl = `/v2/shipping-order/fee`;
 const getPickingShiftUrl = `/v2/shift/date`;
+const calcExpectedDeliveryDateUrl = `/v2/shipping-order/leadtime`;
 const getProvinceUrl = `${baseURL}/master-data/province`;
 const getDistrictUrl = `${baseURL}/master-data/district`;
 const getWardUrl = `${baseURL}/master-data/ward`;
@@ -46,7 +49,11 @@ export function getAvailableServiceAPI(data: GetAvailableServiceRequestProps) {
 }
 
 export function getPickupDateAPI() {
-  return axiosGHN.post<GetAvailableServiceResponseProps>(getPickingShiftUrl);
+  return axiosGHN.post(getPickingShiftUrl);
+}
+
+export function calcExpectedDeliveryDateAPI(data: CalcExpectedDeliveryDateRequest) {
+  return axiosGHN.post<CalcExpectedDeliveryDateResponse>(calcExpectedDeliveryDateUrl, data);
 }
 
 export function getProvinceAPI() {

--- a/src/apis/ghn.ts
+++ b/src/apis/ghn.ts
@@ -21,6 +21,7 @@ const baseURL = 'https://dev-online-gateway.ghn.vn/shiip/public-api';
 const createStoreUrl = `/v2/shop/register`;
 const getServiceUrl = `/v2/shipping-order/available-services`;
 const calcShippingFeeUrl = `/v2/shipping-order/fee`;
+const getPickingShiftUrl = `/v2/shift/date`;
 const getProvinceUrl = `${baseURL}/master-data/province`;
 const getDistrictUrl = `${baseURL}/master-data/district`;
 const getWardUrl = `${baseURL}/master-data/ward`;
@@ -42,6 +43,10 @@ export function calcShippingFeeAPI(data: CalcShippingFeeRequestProps) {
 
 export function getAvailableServiceAPI(data: GetAvailableServiceRequestProps) {
   return axiosGHN.post<GetAvailableServiceResponseProps>(getServiceUrl, data);
+}
+
+export function getPickupDateAPI() {
+  return axiosGHN.post<GetAvailableServiceResponseProps>(getPickingShiftUrl);
 }
 
 export function getProvinceAPI() {

--- a/src/controllers/order.controller.ts
+++ b/src/controllers/order.controller.ts
@@ -22,11 +22,6 @@ const updateOrderStage = catchErrors(async (req: Request, res: Response) => {
   res.status(StatusCodes.OK).json(result).send('<p>some html</p>');
 });
 
-const payByMomo = catchErrors(async (req: Request, res: Response) => {
-  const result = await orderService.payByMomo(req, res);
-  res.status(StatusCodes.OK).json(result).send();
-});
-
 const placeOrder = catchErrors(async (req: Request, res: Response) => {
   const { paymentMethodID } = req.body as CreateCODPaymentRequestProps;
   const paymentMethod = await PaymentMethodModel.findOne({ _id: paymentMethodID });
@@ -61,6 +56,11 @@ const getAvailableService = catchErrors(async (req: Request, res: Response) => {
   res.status(StatusCodes.OK).json(result).send();
 });
 
+const getPickupDate = catchErrors(async (req: Request, res: Response) => {
+  const result = await orderService.getPickupDate(req, res);
+  res.status(StatusCodes.OK).json(result).send();
+});
+
 export const orderController = {
   findAll,
   addOrderWithMoMo,
@@ -69,4 +69,5 @@ export const orderController = {
   calcShippingFee,
   placeOrder,
   getAvailableService,
+  getPickupDate
 };

--- a/src/controllers/order.controller.ts
+++ b/src/controllers/order.controller.ts
@@ -61,6 +61,11 @@ const getPickupDate = catchErrors(async (req: Request, res: Response) => {
   res.status(StatusCodes.OK).json(result).send();
 });
 
+const calcExpectedDeliveryDate = catchErrors(async (req: Request, res: Response) => {
+  const result = await orderService.calcExpectedDeliveryDate(req, res);
+  res.status(StatusCodes.OK).json(result).send();
+});
+
 export const orderController = {
   findAll,
   addOrderWithMoMo,
@@ -69,5 +74,6 @@ export const orderController = {
   calcShippingFee,
   placeOrder,
   getAvailableService,
-  getPickupDate
+  getPickupDate,
+  calcExpectedDeliveryDate,
 };

--- a/src/routers/v1/customerRoutes/order.routes.ts
+++ b/src/routers/v1/customerRoutes/order.routes.ts
@@ -16,6 +16,7 @@ const {
   calcShippingFee,
   placeOrder,
   getAvailableService,
+  getPickupDate,
 } = orderController;
 const { Read, Create } = ActionPermission.Order;
 
@@ -25,6 +26,9 @@ router.route('/place_order').post(placeOrder);
 router.route('/callback').post(isCheckout, addOrderWithMoMo);
 router.route('/check_transaction').post(checkPaymentTransaction);
 router.route('/calc_shipping_fee').post(shippingValidation.calcShippingFee, calcShippingFee);
-router.route('/available_service').post(shippingValidation.getAvailableService, getAvailableService);
+router
+  .route('/available_service')
+  .post(shippingValidation.getAvailableService, getAvailableService);
+router.route('/pickup-date').get(getPickupDate);
 
 export const orderRoutes = router;

--- a/src/routers/v1/customerRoutes/order.routes.ts
+++ b/src/routers/v1/customerRoutes/order.routes.ts
@@ -17,6 +17,7 @@ const {
   placeOrder,
   getAvailableService,
   getPickupDate,
+  calcExpectedDeliveryDate,
 } = orderController;
 const { Read, Create } = ActionPermission.Order;
 
@@ -30,5 +31,8 @@ router
   .route('/available_service')
   .post(shippingValidation.getAvailableService, getAvailableService);
 router.route('/pickup-date').get(getPickupDate);
+router
+  .route('/delivery-time')
+  .post(shippingValidation.calcExpectedDeliveryDate, calcExpectedDeliveryDate);
 
 export const orderRoutes = router;

--- a/src/services/order.service.ts
+++ b/src/services/order.service.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { Request, Response } from 'express';
 import { ReasonPhrases, StatusCodes } from 'http-status-codes';
-import { calcShippingFeeAPI, getAvailableServiceAPI } from '../apis/ghn';
+import { calcShippingFeeAPI, getAvailableServiceAPI, getPickupDateAPI } from '../apis/ghn';
 import { createMoMoPayment } from '../apis/momo';
 import { MOMO } from '../constants/momo';
 import { pagination } from '../constants/pagination';
@@ -203,6 +203,11 @@ const getAvailableService = catchServiceFunc(async (req: Request, res: Response)
   return service.data;
 });
 
+const getPickupDate = catchServiceFunc(async (req: Request, res: Response) => {
+  const service = await getPickupDateAPI();
+  return service.data;
+});
+
 export const orderService = {
   findAll,
   addOrderWithMoMo,
@@ -212,4 +217,5 @@ export const orderService = {
   calcShippingFee,
   addOrderWithCOD,
   getAvailableService,
+  getPickupDate,
 };

--- a/src/services/order.service.ts
+++ b/src/services/order.service.ts
@@ -1,7 +1,12 @@
 import axios from 'axios';
 import { Request, Response } from 'express';
 import { ReasonPhrases, StatusCodes } from 'http-status-codes';
-import { calcShippingFeeAPI, getAvailableServiceAPI, getPickupDateAPI } from '../apis/ghn';
+import {
+  calcExpectedDeliveryDateAPI,
+  calcShippingFeeAPI,
+  getAvailableServiceAPI,
+  getPickupDateAPI,
+} from '../apis/ghn';
 import { createMoMoPayment } from '../apis/momo';
 import { MOMO } from '../constants/momo';
 import { pagination } from '../constants/pagination';
@@ -11,6 +16,7 @@ import { OrderStageModel } from '../models/orderStage';
 import { AppError } from '../types/error.type';
 import { IPNMoMoPaymentRequestProps, MoMoPaymentItemsProps } from '../types/http/momoPayment.type';
 import {
+  CalcExpectedDeliveryDateRequest,
   CalcShippingFeeResponseProps,
   CreateCODPaymentRequestProps,
 } from '../types/http/order.type';
@@ -208,6 +214,12 @@ const getPickupDate = catchServiceFunc(async (req: Request, res: Response) => {
   return service.data;
 });
 
+const calcExpectedDeliveryDate = catchServiceFunc(async (req: Request, res: Response) => {
+  const data = req.body as CalcExpectedDeliveryDateRequest;
+  const service = await calcExpectedDeliveryDateAPI(data);
+  return service.data;
+});
+
 export const orderService = {
   findAll,
   addOrderWithMoMo,
@@ -218,4 +230,5 @@ export const orderService = {
   addOrderWithCOD,
   getAvailableService,
   getPickupDate,
+  calcExpectedDeliveryDate,
 };

--- a/src/types/http/ghn.type.ts
+++ b/src/types/http/ghn.type.ts
@@ -15,6 +15,7 @@ export interface CreateGHNStoreRequestProps {
   address: string;
   token?: string;
 }
+
 export interface CreateGHNStoreResponseProps {
   shop_id: number;
 }

--- a/src/types/http/order.type.ts
+++ b/src/types/http/order.type.ts
@@ -22,6 +22,7 @@ export interface CalcShippingFeeRequestProps {
   cod_value?: number;
   items?: CalcShippingFeeItemProps[];
 }
+
 export interface CalcShippingFeeResponseProps extends GHNResponseProps {
   data: {
     total: number;
@@ -44,7 +45,27 @@ export interface CreatedOrderProps
   extends Pick<OrderProps, 'storeID' | 'total' | 'note' | 'shipmentCost'> {
   items: MoMoPaymentItemsProps[];
 }
+
 export interface CreateCODPaymentRequestProps
   extends Pick<OrderProps, 'userID' | 'total' | 'paymentMethodID' | 'receiverAddress'> {
   orders: CreatedOrderProps[];
+}
+
+export interface CalcExpectedDeliveryDateRequest {
+  ShopID?: number;
+  from_district_id: number;
+  from_ward_code: string;
+  to_district_id: number;
+  to_ward_code: string;
+  service_id?: string;
+}
+
+export interface CalcExpectedDeliveryDateResponse extends GHNResponseProps {
+  data: {
+    leadtime: number;
+    leadtime_order: {
+      from_estimate_date: string;
+      to_estimate_date: string;
+    };
+  };
 }

--- a/src/validations/shipping.validation.ts
+++ b/src/validations/shipping.validation.ts
@@ -1,11 +1,15 @@
 import Joi from 'joi';
-import { CalcShippingFeeRequestProps } from '../types/http/order.type';
+import {
+  CalcExpectedDeliveryDateRequest,
+  CalcShippingFeeRequestProps,
+} from '../types/http/order.type';
 import { catchErrors } from '../utils/catchErrors';
 import { NextFunction, Request, Response } from 'express';
 import { CalcShippingFeeItemProps, GetAvailableServiceRequestProps } from '../types/http/ghn.type';
 
 interface CalcShippingFeeSchema extends CalcShippingFeeRequestProps {}
 interface GetAvailableServiceSchema extends GetAvailableServiceRequestProps {}
+interface CalcExpectedDeliveryDateSchema extends CalcExpectedDeliveryDateRequest {}
 
 const calcShippingFeeSchema = Joi.object<CalcShippingFeeSchema>({
   shopid: Joi.number().required(),
@@ -40,6 +44,15 @@ const getAvailableServiceSchema = Joi.object<GetAvailableServiceSchema>({
   to_district: Joi.number().required(),
 });
 
+const calcExpectedDeliveryDateSchema = Joi.object<CalcExpectedDeliveryDateSchema>({
+  ShopID: Joi.number().allow(null, ''),
+  from_district_id: Joi.number().required(),
+  from_ward_code: Joi.string().required(),
+  to_district_id: Joi.number().required(),
+  to_ward_code: Joi.string().required(),
+  service_id: Joi.number().allow(null, ''),
+});
+
 const calcShippingFee = catchErrors(async (req: Request, res: Response, next: NextFunction) => {
   await calcShippingFeeSchema.validateAsync(req.body, { abortEarly: false });
   next();
@@ -50,4 +63,15 @@ const getAvailableService = catchErrors(async (req: Request, res: Response, next
   next();
 });
 
-export const shippingValidation = { calcShippingFee, getAvailableService };
+const calcExpectedDeliveryDate = catchErrors(
+  async (req: Request, res: Response, next: NextFunction) => {
+    await calcExpectedDeliveryDateSchema.validateAsync(req.body, { abortEarly: false });
+    next();
+  },
+);
+
+export const shippingValidation = {
+  calcShippingFee,
+  getAvailableService,
+  calcExpectedDeliveryDate,
+};


### PR DESCRIPTION
## 1. POST: `/orders/delivery-time`
This api is called **_before shop confirms the order_**

![image](https://github.com/user-attachments/assets/a54b83e1-ad84-4382-9dcc-17fdaaea0892)

---
### Body: `CalcExpectedDeliveryDateRequest`:
- `ShopID`: number _(optional)_
- `from_district_id`: number
- `from_ward_code`: string
- `to_district_id`: number
- `to_ward_code`: string
- `service_id`: string (optional)


### Response: 
- `leadtime`: number (_timestamp_)
- `leadtime_order`: {
  - `from_estimate_date`: string
  - `to_estimate_date`: string;
}

### Example:
![image](https://github.com/user-attachments/assets/81c03465-0d2d-45d2-ac49-4490358769eb)



---



## 2. GET: `/orders/pickup-date`
This api is called **_before shop confirms the order is prepared successfully__**

![image](https://github.com/user-attachments/assets/717db987-9ea1-4cf3-a96f-347ba4ea6bc4)

---

### Response: 
{
- `id`: number 
- `title`: string
- `from_time`: number (ms)
-  `to_time`: number (ms)
    } [ ]

### Example:
![image](https://github.com/user-attachments/assets/e4e039f2-bb25-4053-a3f0-b1336bcdb962)
