### PR TITLE
feat: defined an API to creating new order request & refactor the OrderRequest props

### DIFF
--- a/src/controllers/orderRequest.controller.ts
+++ b/src/controllers/orderRequest.controller.ts
@@ -10,7 +10,7 @@ const findAll = catchErrors(async (req: Request, res: Response) => {
 });
 
 const addOrderRequest = catchErrors(async (req: Request, res: Response) => {
-  const result = await orderRequestService.addOrderRequest(req.body, res);
+  const result = await orderRequestService.addOrderRequest(req, res);
   res.status(StatusCodes.OK).json(result).send();
 });
 

--- a/src/controllers/reason.controller.ts
+++ b/src/controllers/reason.controller.ts
@@ -9,12 +9,12 @@ const findAll = catchErrors(async (req: Request, res: Response) => {
   res.status(StatusCodes.OK).json(result).send();
 });
 
-const addReason = catchErrors(async (req: Request, res: Response) => {
-  const result = await reasonService.addReason(req.body, res);
+const createReason = catchErrors(async (req: Request, res: Response) => {
+  const result = await reasonService.createReason(req.body);
   res.status(StatusCodes.OK).json(result).send();
 });
 
 export const reasonController = {
   findAll,
-  addReason,
+  createReason,
 };

--- a/src/models/orderRequest/orderRequest.doc.ts
+++ b/src/models/orderRequest/orderRequest.doc.ts
@@ -30,7 +30,7 @@ export const ORDERREQUEST_COLLECTION_SCHEMA = new Schema<OrderRequestDocument>(
         type: String,
       },
     ],
-    task: {
+    taskType: {
       type: String,
       enum: {
         values: [TaskType.Cancel, TaskType.Return],

--- a/src/models/reason/reason.doc.ts
+++ b/src/models/reason/reason.doc.ts
@@ -1,5 +1,7 @@
 import mongoose, { Schema } from 'mongoose';
 import { ReasonProps } from '../../types/model/reason.type';
+import { TaskType } from '../../types/enum/taskType.enum';
+import { ObjectType } from '../../types/enum/objectType.enum';
 
 export interface ReasonDocument extends ReasonProps, Document {}
 
@@ -14,14 +16,19 @@ export const REASON_COLLECTION_SCHEMA = new Schema<ReasonDocument>({
   name: {
     type: String,
     required: true,
-    unique: true,
   },
   objectType: {
     type: String,
     required: true,
+    enum: {
+      values: [ObjectType.Product, ObjectType.Review, ObjectType.Store, ObjectType.User],
+    },
   },
   taskType: {
     type: String,
     required: true,
+    enum: {
+      values: [TaskType.Cancel, TaskType.Return],
+    },
   },
 });

--- a/src/routers/v1/customerRoutes/index.ts
+++ b/src/routers/v1/customerRoutes/index.ts
@@ -5,6 +5,7 @@ import {
   CATEGORY_ROUTE,
   ORDER_ROUTE,
   ORDER_STAGE_STATUS_ROUTE,
+  ORDERREQUEST_ROUTE,
   ORDERSTAGE_ROUTE,
   PRODUCT_ROUTE,
   STORE_ROUTE,
@@ -19,6 +20,7 @@ import { orderRoutes } from './order.routes';
 import { storeRoutes } from './store.routes';
 import { orderStageRoutes } from './orderStage.routes';
 import { orderStageStatusRoutes } from './orderStageStatus.routes';
+import { orderRequestRoutes } from '../orderRequest.routes';
 
 const router = express.Router();
 
@@ -29,7 +31,8 @@ router.use(CART_ROUTE, isAuthorized, cartRoutes);
 router.use(USER_ROUTE, userRoutes);
 router.use(ORDER_ROUTE, isAuthorized, orderRoutes);
 router.use(STORE_ROUTE, storeRoutes);
-router.use(ORDERSTAGE_ROUTE, isAuthorized,orderStageRoutes);
+router.use(ORDERSTAGE_ROUTE, isAuthorized, orderStageRoutes);
 router.use(ORDER_STAGE_STATUS_ROUTE, isAuthorized, orderStageStatusRoutes);
+router.use(ORDERREQUEST_ROUTE, orderRequestRoutes);
 
 export const customerRouter = router;

--- a/src/routers/v1/index.ts
+++ b/src/routers/v1/index.ts
@@ -42,7 +42,6 @@ router.use(PAYMENTMETHOD_ROUTE, paymentMethodRoutes);
 router.use(REASON_ROUTE, reasonRoutes);
 
 router.use(ORDERDETAIL_ROUTE, orderDetailRoutes);
-router.use(ORDERREQUEST_ROUTE, orderRequestRoutes);
 router.use(REPORT_ROUTE, reportRoutes);
 
 export const APIs_V1 = router;

--- a/src/routers/v1/reason.routes.ts
+++ b/src/routers/v1/reason.routes.ts
@@ -4,6 +4,6 @@ import { reasonValidation } from '../../validations/reason.validation';
 const router = express.Router();
 
 router.route('/').get(reasonController.findAll);
-router.route('/').post(reasonValidation, reasonController.addReason);
+router.route('/').post(reasonValidation, reasonController.createReason);
 
 export const reasonRoutes = router;

--- a/src/services/orderRequest.service.ts
+++ b/src/services/orderRequest.service.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from 'express';
 import { OrderRequestModel } from '../models/orderRequest';
-import { OrderRequestDocument } from '../models/orderRequest/orderRequest.doc';
+import { CreateOrderRequestRequest } from '../types/http/orderRequest.type';
+import { catchServiceFunc } from '../utils/catchErrors';
+import { ReplyStatus } from '../types/enum/replyStatus.enum';
+import { TaskType } from '../types/enum/taskType.enum';
+import { ObjectType } from '../types/enum/objectType.enum';
 
 const findAll = async (reqBody: Request, res: Response) => {
   try {
@@ -11,15 +15,10 @@ const findAll = async (reqBody: Request, res: Response) => {
   }
 };
 
-const addOrderRequest = async (reqBody: OrderRequestDocument, res: Response) => {
-  try {
-    const orderRequest = reqBody;
-
-    const newOrderRequest = await OrderRequestModel.create(orderRequest);
-    return { newOrderRequest };
-  } catch (error) {
-    console.error(error);
-  }
-};
+const addOrderRequest = catchServiceFunc(async (req: Request, res: Response) => {
+  const orderRequest = req.body as CreateOrderRequestRequest;
+  const newOrderRequest = await OrderRequestModel.create(orderRequest);
+  return newOrderRequest;
+});
 
 export const orderRequestService = { findAll, addOrderRequest };

--- a/src/services/reason.service.ts
+++ b/src/services/reason.service.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from 'express';
 import { ReasonModel } from '../models/reason';
 import { ReasonDocument } from '../models/reason/reason.doc';
+import { CreateReasonRequest } from '../types/http/reason.type';
+import { AppError } from '../types/error.type';
+import ApiError from '../utils/classes/ApiError';
 
 const findAll = async (reqBody: Request, res: Response) => {
   try {
@@ -11,15 +14,13 @@ const findAll = async (reqBody: Request, res: Response) => {
   }
 };
 
-const addReason = async (reqBody: ReasonDocument, res: Response) => {
+const createReason = async (reason: CreateReasonRequest) => {
   try {
-    const reason = reqBody;
-
     const newReason = await ReasonModel.create(reason);
-    return { newReason };
-  } catch (error) {
-    console.error(error);
+    return newReason;
+  } catch (error: AppError) {
+    return new ApiError({ message: error.message, statusCode: error.statusCode });
   }
 };
 
-export const reasonService = { findAll, addReason };
+export const reasonService = { findAll, createReason };

--- a/src/types/http/orderRequest.type.ts
+++ b/src/types/http/orderRequest.type.ts
@@ -1,0 +1,4 @@
+import { OrderRequestProps } from '../model/orderRequest.type';
+
+export interface CreateOrderRequestRequest
+  extends Omit<OrderRequestProps, '_id' | 'replyMessage'> {}

--- a/src/types/http/reason.type.ts
+++ b/src/types/http/reason.type.ts
@@ -1,0 +1,3 @@
+import { ReasonProps } from "../model/reason.type";
+
+export interface CreateReasonRequest extends Omit<ReasonProps, '_id'> {}

--- a/src/types/model/orderRequest.type.ts
+++ b/src/types/model/orderRequest.type.ts
@@ -9,7 +9,7 @@ export interface OrderRequestProps {
   video?: string[];
   taskType: TaskType;
   replyStatus: ReplyStatus;
-  replyMessage: string;
+  replyMessage?: string;
   reasonID: mongoose.Types.ObjectId;
   orderStageStatusID: mongoose.Types.ObjectId;
   createAt?: Date;

--- a/src/types/model/orderRequest.type.ts
+++ b/src/types/model/orderRequest.type.ts
@@ -1,12 +1,14 @@
 import mongoose from 'mongoose';
+import { TaskType } from '../enum/taskType.enum';
+import { ReplyStatus } from '../enum/replyStatus.enum';
 
 export interface OrderRequestProps {
   _id: mongoose.Types.ObjectId;
   description: string;
-  image: string[];
-  video: string[];
-  task: string;
-  replyStatus: string;
+  image?: string[];
+  video?: string[];
+  taskType: TaskType;
+  replyStatus: ReplyStatus;
   replyMessage: string;
   reasonID: mongoose.Types.ObjectId;
   orderStageStatusID: mongoose.Types.ObjectId;

--- a/src/types/model/reason.type.ts
+++ b/src/types/model/reason.type.ts
@@ -1,10 +1,12 @@
-import mongoose from "mongoose";
+    import mongoose from "mongoose";
+import { TaskType } from "../enum/taskType.enum";
+import { ObjectType } from "../enum/objectType.enum";
 
 export interface ReasonProps{
     _id: mongoose.Schema.Types.ObjectId,
     name: string,
-    objectType: string,
-    taskType: string,
+    objectType: ObjectType,
+    taskType: TaskType,
     createAt?: Date,
     updateAt?: Date,
 }

--- a/src/validations/orderRequest.validation.ts
+++ b/src/validations/orderRequest.validation.ts
@@ -1,23 +1,25 @@
-import Joi, { string } from 'joi';
-import { catchErrors } from '../utils/catchErrors';
 import { NextFunction, Request, Response } from 'express';
-import { OrderRequestProps } from '../types/model/orderRequest.type';
+import Joi from 'joi';
 import { ReplyStatus } from '../types/enum/replyStatus.enum';
 import { TaskType } from '../types/enum/taskType.enum';
-import { ObjectIDRegex } from '../constants/validation';
+import { CreateOrderRequestRequest } from '../types/http/orderRequest.type';
+import { catchErrors } from '../utils/catchErrors';
 import { CommonValidation } from './common.validation';
 
-interface OrderRequestSchema extends OrderRequestProps {}
+interface OrderRequestSchema extends CreateOrderRequestRequest {}
 
 const { idSchema } = CommonValidation;
 
 const orderRequestSchema = Joi.object<OrderRequestSchema>({
   description: Joi.string().default(null),
-  image: [Joi.string()],
-  video: [Joi.string()],
-  taskType: Joi.string().valid(TaskType.Cancel, TaskType.Return).required(),
-  replyStatus: Joi.string().valid(ReplyStatus).default(ReplyStatus.Pending),
-  replyMessage: Joi.string().default(null),
+  image: Joi.array().items(Joi.string()).allow(null, ''),
+  video: Joi.array().items(Joi.string()).allow(null, ''),
+  taskType: Joi.string()
+    .valid(...Object.values(TaskType))
+    .required(),
+  replyStatus: Joi.string()
+    .valid(...Object.values(ReplyStatus))
+    .default(ReplyStatus.Pending),
   reasonID: idSchema.required(),
   orderStageStatusID: idSchema.required(),
 });

--- a/src/validations/orderRequest.validation.ts
+++ b/src/validations/orderRequest.validation.ts
@@ -15,7 +15,7 @@ const orderRequestSchema = Joi.object<OrderRequestSchema>({
   description: Joi.string().default(null),
   image: [Joi.string()],
   video: [Joi.string()],
-  task: Joi.string().valid(TaskType.Cancel, TaskType.Return).required(),
+  taskType: Joi.string().valid(TaskType.Cancel, TaskType.Return).required(),
   replyStatus: Joi.string().valid(ReplyStatus).default(ReplyStatus.Pending),
   replyMessage: Joi.string().default(null),
   reasonID: idSchema.required(),
@@ -24,7 +24,6 @@ const orderRequestSchema = Joi.object<OrderRequestSchema>({
 
 export const orderRequestValidation = catchErrors(
   async (req: Request, res: Response, next: NextFunction) => {
-    // abortEarly: false will return all errors found in the request bod
     await orderRequestSchema.validateAsync(req.body, { abortEarly: false });
     next();
   },

--- a/src/validations/reason.validation.ts
+++ b/src/validations/reason.validation.ts
@@ -1,21 +1,24 @@
-import Joi from 'joi';
-import { catchErrors } from '../utils/catchErrors';
 import { NextFunction, Request, Response } from 'express';
-import { ReasonProps } from '../types/model/reason.type';
+import Joi from 'joi';
 import { ObjectType } from '../types/enum/objectType.enum';
 import { TaskType } from '../types/enum/taskType.enum';
+import { CreateReasonRequest } from '../types/http/reason.type';
+import { catchErrors } from '../utils/catchErrors';
 
-interface ReasonSchema extends ReasonProps {}
+interface ReasonSchema extends CreateReasonRequest {}
 
 const reasonSchema = Joi.object<ReasonSchema>({
   name: Joi.string().required().trim(),
-  objectType: Joi.string().valid(ObjectType).required(),
-  taskType: Joi.string().valid(TaskType).required(),
+  objectType: Joi.string()
+    .valid(...Object.values(ObjectType))
+    .required(),
+  taskType: Joi.string()
+    .valid(...Object.values(TaskType))
+    .required(),
 });
 
 export const reasonValidation = catchErrors(
   async (req: Request, res: Response, next: NextFunction) => {
-    // abortEarly: false will return all errors found in the request bod
     await reasonSchema.validateAsync(req.body, { abortEarly: false });
     next();
   },


### PR DESCRIPTION
## 1. POST: `/orderrequests`
This API is used to creating a new order request

### Body: `CreateOrderRequestRequest`:
```
export interface CreateOrderRequestRequest
  extends Omit<OrderRequestProps, '_id' | 'replyMessage'> {}
```
### Body Schema:
![image](https://github.com/user-attachments/assets/bffa4f12-2318-4753-bf5d-6e7ea76c955a)

### Response: `OrderRequestProps`

---

## 2. Changing ~~task~~ to `taskType` in `OrderRequestProps`:
````
export interface OrderRequestProps {
  _id: mongoose.Types.ObjectId;
  description: string;
  image?: string[];
  video?: string[];
  taskType: TaskType;
  replyStatus: ReplyStatus;
  replyMessage?: string;
  reasonID: mongoose.Types.ObjectId;
  orderStageStatusID: mongoose.Types.ObjectId;
  createAt?: Date;
  updateAt?: Date;
}