### PR TITLE
feat: defined an API to replying order request & add middleware to checking order stage

### DIFF
--- a/src/constants/httpMessage.ts
+++ b/src/constants/httpMessage.ts
@@ -1,4 +1,5 @@
 import { ReasonPhrases } from 'http-status-codes';
+import { OrderStage } from '../types/enum/orderStage.enum';
 
 const TOKEN = 'Token';
 const OTP = 'OTP';
@@ -13,6 +14,7 @@ const getNotFoundMsg = (title: string) => `${title} ${ReasonPhrases.NOT_FOUND}`;
 const getConflictMsg = (title: string) => `${title} already exists`;
 const getExpiredMsg = (title: string) => `${title} has expired`;
 const getIncorrectMsg = (title: string) => `Incorrect ${title}`;
+const getOrderStageConditionMsg = (orderStage: OrderStage) => `Stage's order must be ${orderStage}`;
 
 const EXPIRED_MGS = {
   TOKEN: getExpiredMsg(TOKEN),
@@ -34,6 +36,10 @@ const CONFLICT = {
   USER: getConflictMsg(USER),
 };
 
+const ORDER_STAGE_CONDITION = {
+  PICKING: getOrderStageConditionMsg(OrderStage.Picking),
+};
+
 export const HttpMessage = {
   NOT_FOUND,
   EXPIRED_MGS,
@@ -42,4 +48,5 @@ export const HttpMessage = {
   NOT_VERIFY,
   OUT_OF_STOCK,
   ACCESS_DENIED,
+  ORDER_STAGE_CONDITION
 };

--- a/src/controllers/orderRequest.controller.ts
+++ b/src/controllers/orderRequest.controller.ts
@@ -14,7 +14,13 @@ const addOrderRequest = catchErrors(async (req: Request, res: Response) => {
   res.status(StatusCodes.OK).json(result).send();
 });
 
+const reply = catchErrors(async (req: Request, res: Response) => {
+  const result = await orderRequestService.reply(req, res);
+  res.status(StatusCodes.OK).json(result).send();
+});
+
 export const orderRequestController = {
   findAll,
   addOrderRequest,
+  reply,
 };

--- a/src/middlewares/orderRequesst.middleware.ts
+++ b/src/middlewares/orderRequesst.middleware.ts
@@ -1,0 +1,33 @@
+import { StatusCodes } from 'http-status-codes';
+import { HttpMessage } from '../constants/httpMessage';
+import { OrderRequestModel } from '../models/orderRequest';
+import { OrderRequestDocument } from '../models/orderRequest/orderRequest.doc';
+import { OrderStage } from '../types/enum/orderStage.enum';
+import { ReplyOrderRequestRequest } from '../types/http/orderRequest.type';
+import { catchErrors, handleError } from '../utils/catchErrors';
+
+const isReplied = catchErrors(async (req, res, next) => {
+  const { _id } = req.body as ReplyOrderRequestRequest;
+  const orderRequest = (await OrderRequestModel.findOne({ _id }).populate({
+    path: 'orderStageStatusID',
+    select: 'orderStageID',
+    populate: { path: 'orderStageID', select: 'name' },
+  })) as
+    | (OrderRequestDocument & { orderStageStatusID: { orderStageID: { name: OrderStage } } })
+    | null;
+
+  const orderStageName = orderRequest?.orderStageStatusID?.orderStageID
+    ?.name as unknown as OrderStage;
+
+  if (orderStageName === OrderStage.Picking) {
+    next();
+  }
+
+  handleError({
+    message: HttpMessage.ORDER_STAGE_CONDITION.PICKING,
+    statusCode: StatusCodes.BAD_REQUEST,
+    next,
+  });
+});
+
+export const orderRequestMiddleware = { isReplied };

--- a/src/models/orderRequest/orderRequest.doc.ts
+++ b/src/models/orderRequest/orderRequest.doc.ts
@@ -43,6 +43,7 @@ export const ORDERREQUEST_COLLECTION_SCHEMA = new Schema<OrderRequestDocument>(
         values: [ReplyStatus.Pending, ReplyStatus.Succeeded, ReplyStatus.Rejected],
       },
       default: ReplyStatus.Pending,
+      required: true,
     },
     replyMessage: {
       type: String,

--- a/src/routers/v1/orderRequest.routes.ts
+++ b/src/routers/v1/orderRequest.routes.ts
@@ -3,7 +3,9 @@ import { orderRequestController } from '../../controllers/orderRequest.controlle
 import { orderRequestValidation } from '../../validations/orderRequest.validation';
 const router = express.Router();
 
+const { createValidation, replyValidation } = orderRequestValidation;
 router.route('/').get(orderRequestController.findAll);
-router.route('/').post(orderRequestValidation ,orderRequestController.addOrderRequest);
+router.route('/').post(createValidation, orderRequestController.addOrderRequest);
+router.route('/').put(replyValidation, orderRequestController.reply);
 
 export const orderRequestRoutes = router;

--- a/src/routers/v1/orderRequest.routes.ts
+++ b/src/routers/v1/orderRequest.routes.ts
@@ -1,11 +1,13 @@
 import express from 'express';
 import { orderRequestController } from '../../controllers/orderRequest.controller';
 import { orderRequestValidation } from '../../validations/orderRequest.validation';
+import { orderRequestMiddleware } from '../../middlewares/orderRequesst.middleware';
 const router = express.Router();
 
+const { isReplied } = orderRequestMiddleware;
 const { createValidation, replyValidation } = orderRequestValidation;
 router.route('/').get(orderRequestController.findAll);
 router.route('/').post(createValidation, orderRequestController.addOrderRequest);
-router.route('/').put(replyValidation, orderRequestController.reply);
+router.route('/').put(isReplied, replyValidation, orderRequestController.reply);
 
 export const orderRequestRoutes = router;

--- a/src/services/orderRequest.service.ts
+++ b/src/services/orderRequest.service.ts
@@ -5,6 +5,13 @@ import {
   ReplyOrderRequestRequest,
 } from '../types/http/orderRequest.type';
 import { catchServiceFunc } from '../utils/catchErrors';
+import { ReplyStatus } from '../types/enum/replyStatus.enum';
+import { OrderModel } from '../models/order';
+import { OrderStageStatusModel } from '../models/orderStageStatus';
+import { orderStageService } from './orderStage.service';
+import { OrderStage } from '../types/enum/orderStage.enum';
+import { OrderRequestDocument } from '../models/orderRequest/orderRequest.doc';
+import mongoose from 'mongoose';
 
 const findAll = async (reqBody: Request, res: Response) => {
   try {
@@ -18,16 +25,42 @@ const findAll = async (reqBody: Request, res: Response) => {
 const addOrderRequest = catchServiceFunc(async (req: Request, res: Response) => {
   const orderRequest = req.body as CreateOrderRequestRequest;
   const newOrderRequest = await OrderRequestModel.create(orderRequest);
+  await OrderStageStatusModel.findByIdAndUpdate(orderRequest.orderStageStatusID, {
+    orderRequestID: newOrderRequest._id,
+  });
   return newOrderRequest;
 });
 
 const reply = catchServiceFunc(async (req: Request, res: Response) => {
   const { _id, replyMessage, replyStatus } = req.body as ReplyOrderRequestRequest;
-  const repliedOrderRequest = await OrderRequestModel.findByIdAndUpdate(
+  const repliedOrderRequest = (await OrderRequestModel.findByIdAndUpdate(
     _id,
     { replyMessage, replyStatus },
     { new: true },
-  );
+  ).populate({ path: 'orderStageStatusID', populate: { path: 'orderStageID' } })) as
+    | (OrderRequestDocument & { orderStageStatusID: { orderStageID: { orderID: string } } })
+    | null;
+
+  // if approved, move order to the cancelled stage
+  if (replyStatus === ReplyStatus.Succeeded) {
+    const orderID = repliedOrderRequest?.orderStageStatusID?.orderStageID
+      ?.orderID as unknown as mongoose.Types.ObjectId;
+
+    const orderStage = await orderStageService.createOne({
+      name: OrderStage.Cancelled,
+      orderID,
+    });
+
+    //update order with new orderStage
+    await OrderModel.findByIdAndUpdate(
+      orderID,
+      { orderStageID: orderStage?._id },
+      { new: true },
+    ).populate({
+      path: 'orderStageID',
+      populate: { path: 'orderStageStatusID', populate: 'orderRequestID' },
+    });
+  }
   return repliedOrderRequest;
 });
 

--- a/src/services/orderRequest.service.ts
+++ b/src/services/orderRequest.service.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from 'express';
 import { OrderRequestModel } from '../models/orderRequest';
-import { CreateOrderRequestRequest } from '../types/http/orderRequest.type';
+import {
+  CreateOrderRequestRequest,
+  ReplyOrderRequestRequest,
+} from '../types/http/orderRequest.type';
 import { catchServiceFunc } from '../utils/catchErrors';
-import { ReplyStatus } from '../types/enum/replyStatus.enum';
-import { TaskType } from '../types/enum/taskType.enum';
-import { ObjectType } from '../types/enum/objectType.enum';
 
 const findAll = async (reqBody: Request, res: Response) => {
   try {
@@ -21,4 +21,14 @@ const addOrderRequest = catchServiceFunc(async (req: Request, res: Response) => 
   return newOrderRequest;
 });
 
-export const orderRequestService = { findAll, addOrderRequest };
+const reply = catchServiceFunc(async (req: Request, res: Response) => {
+  const { _id, replyMessage, replyStatus } = req.body as ReplyOrderRequestRequest;
+  const repliedOrderRequest = await OrderRequestModel.findByIdAndUpdate(
+    _id,
+    { replyMessage, replyStatus },
+    { new: true },
+  );
+  return repliedOrderRequest;
+});
+
+export const orderRequestService = { findAll, addOrderRequest, reply };

--- a/src/types/http/orderRequest.type.ts
+++ b/src/types/http/orderRequest.type.ts
@@ -2,3 +2,6 @@ import { OrderRequestProps } from '../model/orderRequest.type';
 
 export interface CreateOrderRequestRequest
   extends Omit<OrderRequestProps, '_id' | 'replyMessage'> {}
+
+export interface ReplyOrderRequestRequest
+  extends Pick<OrderRequestProps, '_id' | 'replyMessage' | 'replyStatus'> {}

--- a/src/types/http/orderRequest.type.ts
+++ b/src/types/http/orderRequest.type.ts
@@ -1,7 +1,7 @@
 import { OrderRequestProps } from '../model/orderRequest.type';
 
 export interface CreateOrderRequestRequest
-  extends Omit<OrderRequestProps, '_id' | 'replyMessage'> {}
+  extends Omit<OrderRequestProps, '_id' | 'replyMessage' | 'replyStatus'> {}
 
 export interface ReplyOrderRequestRequest
   extends Pick<OrderRequestProps, '_id' | 'replyMessage' | 'replyStatus'> {}

--- a/src/validations/orderRequest.validation.ts
+++ b/src/validations/orderRequest.validation.ts
@@ -2,11 +2,15 @@ import { NextFunction, Request, Response } from 'express';
 import Joi from 'joi';
 import { ReplyStatus } from '../types/enum/replyStatus.enum';
 import { TaskType } from '../types/enum/taskType.enum';
-import { CreateOrderRequestRequest } from '../types/http/orderRequest.type';
+import {
+  CreateOrderRequestRequest,
+  ReplyOrderRequestRequest,
+} from '../types/http/orderRequest.type';
 import { catchErrors } from '../utils/catchErrors';
 import { CommonValidation } from './common.validation';
 
 interface OrderRequestSchema extends CreateOrderRequestRequest {}
+interface ReplyOrderRequestSchema extends ReplyOrderRequestRequest {}
 
 const { idSchema } = CommonValidation;
 
@@ -24,9 +28,23 @@ const orderRequestSchema = Joi.object<OrderRequestSchema>({
   orderStageStatusID: idSchema.required(),
 });
 
-export const orderRequestValidation = catchErrors(
-  async (req: Request, res: Response, next: NextFunction) => {
-    await orderRequestSchema.validateAsync(req.body, { abortEarly: false });
-    next();
-  },
-);
+const replyOrderRequestSchema = Joi.object<ReplyOrderRequestSchema>().keys({
+  _id: idSchema.required(),
+  replyMessage: Joi.string().required(),
+  replyStatus: Joi.string().valid(ReplyStatus.Succeeded, ReplyStatus.Rejected).required(),
+});
+
+const createValidation = catchErrors(async (req: Request, res: Response, next: NextFunction) => {
+  await orderRequestSchema.validateAsync(req.body, { abortEarly: false });
+  next();
+});
+
+const replyValidation = catchErrors(async (req: Request, res: Response, next: NextFunction) => {
+  await replyOrderRequestSchema.validateAsync(req.body, { abortEarly: false });
+  next();
+});
+
+export const orderRequestValidation = {
+  createValidation,
+  replyValidation,
+};

--- a/src/validations/orderRequest.validation.ts
+++ b/src/validations/orderRequest.validation.ts
@@ -21,9 +21,6 @@ const orderRequestSchema = Joi.object<OrderRequestSchema>({
   taskType: Joi.string()
     .valid(...Object.values(TaskType))
     .required(),
-  replyStatus: Joi.string()
-    .valid(...Object.values(ReplyStatus))
-    .default(ReplyStatus.Pending),
   reasonID: idSchema.required(),
   orderStageStatusID: idSchema.required(),
 });


### PR DESCRIPTION
## PUT: `/orderrequests`
This API is used to replying order request from Seller/Admin

### Body: `ReplyOrderRequestRequest`:
```
export interface ReplyOrderRequestRequest
  extends Pick<OrderRequestProps, '_id' | 'replyMessage' | 'replyStatus'> {}
```
### Validation:

```
const replyOrderRequestSchema = Joi.object<ReplyOrderRequestSchema>().keys({
  _id: idSchema.required(),
  replyMessage: Joi.string().required(),
  replyStatus: Joi.string().valid(ReplyStatus.Succeeded, ReplyStatus.Rejected).required(),
});
```
- replyStatus must be Succeeded or Rejected